### PR TITLE
Importando o readline sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+const readlineSync = require ('readline-sync'); // import da biblioteca readline sync 


### PR DESCRIPTION
Após instalar o Node ainda é necessário usar esse módulo dentro do nosso arquivo, assim ele poderá usar a função para fazer a interface que lê os dados.